### PR TITLE
:sparkles: 장바구니 담기

### DIFF
--- a/emart-fresh-spring/demo/pom.xml
+++ b/emart-fresh-spring/demo/pom.xml
@@ -120,8 +120,12 @@
 		    <artifactId>cloudinary-http44</artifactId>
 		    <version>1.29.0</version>
 		</dependency>
-
-
+		
+		<dependency>
+		    <groupId>org.modelmapper</groupId>
+		    <artifactId>modelmapper</artifactId>
+		    <version>3.1.1</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/emart-fresh-spring/demo/src/main/java/mart/fresh/com/config/AuthenticationConfig.java
+++ b/emart-fresh-spring/demo/src/main/java/mart/fresh/com/config/AuthenticationConfig.java
@@ -34,9 +34,10 @@ public class AuthenticationConfig {
     	.requestMatchers(new AntPathRequestMatcher("/member/**")).permitAll()
     	.requestMatchers(new AntPathRequestMatcher("/refreshToken/**")).permitAll()
     	.requestMatchers(new AntPathRequestMatcher("/**")).permitAll()
+		.requestMatchers(new AntPathRequestMatcher("/cart/**")).permitAll();
     	//.requestMatchers(new AntPathRequestMatcher("/**")).permitAll();
     	//.requestMatchers(new AntPathRequestMatcher("/review/**")).permitAll()
-        .anyRequest().authenticated(); 	// 이외 모든 요청은 인증필요
+        //.anyRequest().authenticated(); 	// 이외 모든 요청은 인증필요
 		
 		return http.build();
 	}

--- a/emart-fresh-spring/demo/src/main/java/mart/fresh/com/controller/CartController.java
+++ b/emart-fresh-spring/demo/src/main/java/mart/fresh/com/controller/CartController.java
@@ -2,6 +2,7 @@ package mart.fresh.com.controller;
 
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -9,10 +10,13 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import mart.fresh.com.data.dto.AddToCartDto;
 import mart.fresh.com.data.dto.CartInfoDto;
 import mart.fresh.com.service.CartProductService;
 import mart.fresh.com.service.CartService;
@@ -40,6 +44,17 @@ public class CartController {
             return ResponseEntity.ok(cartInfoList);
         }
     }
+	
+	@PostMapping("/addToCart")//수정 : add auth
+	public String addToCart(@RequestBody AddToCartDto dto) {
+
+	    System.out.println("CartController의 장바구니에 추가 " + new Date());
+	    System.out.println("CartController" + dto.getProductName());
+	    System.out.println("CartController" + dto.getRequestQuantity());
+
+	    return cartService.addToCart("abcabc123", dto.getProductName(), dto.getStoreId(), dto.getRequestQuantity());//수정 memid
+
+	}
 	
 	@DeleteMapping("/removeProduct")
     public ResponseEntity<String> removeProductFromCart(Authentication authentication, @RequestParam int cartProductId) {

--- a/emart-fresh-spring/demo/src/main/java/mart/fresh/com/data/dao/CartDao.java
+++ b/emart-fresh-spring/demo/src/main/java/mart/fresh/com/data/dao/CartDao.java
@@ -6,5 +6,5 @@ import mart.fresh.com.data.dto.CartInfoDto;
 
 public interface CartDao {
     List<CartInfoDto> getCartInfo(String memberId);
-
+    String addToCart(String memberId, String productName, int storeId, int requestQuantity);
 }

--- a/emart-fresh-spring/demo/src/main/java/mart/fresh/com/data/dao/impl/CartDaoImpl.java
+++ b/emart-fresh-spring/demo/src/main/java/mart/fresh/com/data/dao/impl/CartDaoImpl.java
@@ -1,6 +1,9 @@
 package mart.fresh.com.data.dao.impl;
 
+import java.sql.Timestamp;
+import java.util.Date;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -11,22 +14,127 @@ import mart.fresh.com.data.dto.CartInfoDto;
 import mart.fresh.com.data.dto.CartProductDto;
 import mart.fresh.com.data.entity.Cart;
 import mart.fresh.com.data.entity.CartProduct;
+import mart.fresh.com.data.entity.Member;
+import mart.fresh.com.data.entity.Product;
+import mart.fresh.com.data.entity.Store;
+import mart.fresh.com.data.entity.StoreProduct;
 import mart.fresh.com.data.repository.CartProductRepository;
 import mart.fresh.com.data.repository.CartRepository;
+import mart.fresh.com.data.repository.MemberRepository;
+import mart.fresh.com.data.repository.StoreRepository;
 
 @Component
 public class CartDaoImpl implements CartDao {
     private final CartRepository cartRepository;
-
+    private final MemberRepository memberRepository;
+    private final StoreRepository storeRepository;
+    private final CartProductRepository cartProductRepository;
     @Autowired
-    public CartDaoImpl(CartRepository cartRepository) {
+    public CartDaoImpl(CartRepository cartRepository, MemberRepository memberRepository,
+    		StoreRepository storeRepository, CartProductRepository cartProductRepository) {
         this.cartRepository = cartRepository;
+        this.memberRepository = memberRepository;
+        this.storeRepository = storeRepository;
+        this.cartProductRepository = cartProductRepository;
     }
 
     @Override
     public List<CartInfoDto> getCartInfo(String memberId) {
     	return cartRepository.getCartInfoByMemberId(memberId);
     }
+
+    
+    //한 번에 총 수량 넘는 만큼 추가하면 error
+    //하지만 장바구니에 나누어서 담아서 수량 추가하는건 ok하도록 로직 구현함
+	@Override
+	public String addToCart(String memberId, String productName, int storeId, int requestQuantity) {
+		
+		//내 카트 받아오기
+		List<Cart> cartList =  cartRepository.findByMemberMemberId(memberId);
+
+		Cart cart = cartList.get(0);
+
+		if(cart == null) return "장바구니 테이블 생성 안 되어있음";
+		
+		//다른 가게가 카트에 이미 존재하면 에러 :
+		//0은 빈 상태, 즉 에러 X
+		if(cart.getStore().getStoreId() != 0 && cart.getStore().getStoreId() != storeId) return "error:another store exist";
+		
+		System.out.println("-------------adst : ");
+		Timestamp currentTimestamp = new Timestamp(System.currentTimeMillis());
+		List<StoreProduct> storeProductList = cartRepository.getAvailableProducts(storeId, productName, currentTimestamp);
+		System.out.println("-------------addToCart productList : ");
+		
+		//해당 상품의 총 개수를 구함
+		if(storeProductList == null || storeProductList.size() <= 0) return "error:out of stock";
+		int sumOfStock = 0;
+		for(StoreProduct sp:storeProductList) {
+			sumOfStock += sp.getStoreProductStock();
+		}
+		if(sumOfStock < requestQuantity) return "error:out of stock";
 	
+			//유통기한 남은 재고 있음 + 재고가 사용자의 요구 개수 충족
+			Store store = storeProductList.get(0).getStore();
+			
+		//2 CartProduct에 프로덕트 및 추가
+		//요구 횟수 채울 떄까지 반복
+		for(StoreProduct sp:storeProductList) {
+			if(requestQuantity <= 0) break;
+			Product productNow = sp.getProduct();
+			int productNowQuantity = sp.getStoreProductStock();
+			
+			//이미 장바구니에 같은 이름의 행 존재하나 확인
+			List<CartProduct> cartProductList = cartProductRepository.findByProduct_ProductTitle(productName);
+			CartProduct cartProduct;
+			
+			//없을시 새로 생성
+			if(cartProductList == null || cartProductList.size() == 0) {
+				cartProduct = new CartProduct();
+			}else {
+				//있을시 기존 엔티티 사용
+				cartProduct = cartProductList.get(0);
+			}
+			int cartExistingQuantity = cartProduct.getCartProductQuantity();
+			
+
+			
+			cartProduct.setCart(cart);
+			cartProduct.setProduct(sp.getProduct());
+			
+			//수량 초과시 최대 개수로 채우고 얼리 리턴
+			if(sumOfStock < cartExistingQuantity + productNowQuantity) {
+				cartProduct.setCartProductQuantity(sumOfStock);
+				cartProductRepository.save(cartProduct);
+				
+				return "error:full of bound";
+			}
+			
+			if (requestQuantity - productNowQuantity < 0) {//요구량 < 수량
+				cartProduct.setCartProductQuantity(cartExistingQuantity + requestQuantity);
+				System.out.println("발생1");
+			    requestQuantity = 0;
+			} else  {// 요구량 > 수량
+				cartProduct.setCartProductQuantity(cartExistingQuantity + productNowQuantity);
+				System.out.println("발생2");
+
+			    requestQuantity -= productNowQuantity;
+			}
+				
+			//실제 주문에 들어가면더 나을 것 같은 로직
+//			//현재 프로덕트에서 주문 개수 채울수 있으면 전체 다 넣기 
+//			if (requestQuantity - productNowQuantity < 0) {
+//				cartProduct.setCartProductQuantity(cartExistingQuantity + requestQuantity);
+//			    requestQuantity = 0;
+//			} else {//부족하면 프로덕트 주문개수만 넣기
+//				cartProduct.setCartProductQuantity(productNowQuantity);
+//			    requestQuantity -= productNowQuantity;
+//			}
+//			
+			cartProductRepository.save(cartProduct);
+		}
+		return "success";
+	}
+
+
 	
 }

--- a/emart-fresh-spring/demo/src/main/java/mart/fresh/com/data/dto/AddToCartDto.java
+++ b/emart-fresh-spring/demo/src/main/java/mart/fresh/com/data/dto/AddToCartDto.java
@@ -1,0 +1,12 @@
+package mart.fresh.com.data.dto;
+
+import java.sql.Timestamp;
+
+import lombok.Data;
+
+@Data
+public class AddToCartDto {
+	int storeId;
+	String productName;
+	int requestQuantity;
+}

--- a/emart-fresh-spring/demo/src/main/java/mart/fresh/com/data/repository/CartProductRepository.java
+++ b/emart-fresh-spring/demo/src/main/java/mart/fresh/com/data/repository/CartProductRepository.java
@@ -10,4 +10,5 @@ public interface CartProductRepository extends JpaRepository<CartProduct, Intege
     List<CartProduct> findByCartMemberMemberId(String memberId);
 
 	void deleteByCartMemberMemberIdAndCartProductId(String memberId, int cartProductId);
+	List<CartProduct> findByProduct_ProductTitle(String productName);
 }

--- a/emart-fresh-spring/demo/src/main/java/mart/fresh/com/data/repository/CartRepository.java
+++ b/emart-fresh-spring/demo/src/main/java/mart/fresh/com/data/repository/CartRepository.java
@@ -1,5 +1,6 @@
 package mart.fresh.com.data.repository;
 
+import java.sql.Timestamp;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -8,6 +9,8 @@ import org.springframework.data.repository.query.Param;
 
 import mart.fresh.com.data.dto.CartInfoDto;
 import mart.fresh.com.data.entity.Cart;
+import mart.fresh.com.data.entity.Product;
+import mart.fresh.com.data.entity.StoreProduct;
 
 public interface CartRepository extends JpaRepository<Cart, Integer>{
     List<Cart> findByMemberMemberId(String memberId);
@@ -19,5 +22,13 @@ public interface CartRepository extends JpaRepository<Cart, Integer>{
     	       "WHERE c.member.memberId = :memberId")
     	List<CartInfoDto> getCartInfoByMemberId(@Param("memberId") String memberId);
 
+    //현재 날짜 기준으로 해당 가게에 해당 상품 재고가 존재하는지 확인
+    @Query("SELECT sp "
+    	    + "FROM StoreProduct sp "
+    	    + "WHERE sp.store.storeId = :storeId AND "
+    	    + "    sp.product.productTitle = :productName AND "
+    	    + "    sp.storeProductStock >= 0 AND "
+    	    + "    sp.product.productExpirationDate >= :now")
+    	List<StoreProduct> getAvailableProducts(@Param("storeId") int storeId, @Param("productName") String productName, @Param("now") Timestamp now);
 
 }

--- a/emart-fresh-spring/demo/src/main/java/mart/fresh/com/data/repository/StoreRepository.java
+++ b/emart-fresh-spring/demo/src/main/java/mart/fresh/com/data/repository/StoreRepository.java
@@ -1,0 +1,9 @@
+package mart.fresh.com.data.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import mart.fresh.com.data.entity.Store;
+
+public interface StoreRepository extends JpaRepository<Store, Integer>{
+	
+}

--- a/emart-fresh-spring/demo/src/main/java/mart/fresh/com/service/CartService.java
+++ b/emart-fresh-spring/demo/src/main/java/mart/fresh/com/service/CartService.java
@@ -5,7 +5,7 @@ import java.util.List;
 import mart.fresh.com.data.dto.CartInfoDto;
 
 public interface CartService {
-
 	List<CartInfoDto> getCartInfo(String memberId);
+    String addToCart(String memberId, String productName, int storeId, int requestQuantity);
 
 }

--- a/emart-fresh-spring/demo/src/main/java/mart/fresh/com/service/impl/CartServiceImpl.java
+++ b/emart-fresh-spring/demo/src/main/java/mart/fresh/com/service/impl/CartServiceImpl.java
@@ -24,4 +24,10 @@ public class CartServiceImpl implements CartService{
         return cartDao.getCartInfo(memberId);
 	}
 
+	@Override
+	public String addToCart(String memberId, String productName, int storeId, int requestQuantity) {
+		
+		return cartDao.addToCart(memberId, productName, storeId, requestQuantity);
+	}
+
 }


### PR DESCRIPTION
- #11 장바구니 담기 백엔드 구현
- 동일한 이름으로는 하나의 행만 생성됌
- 하나의 가게에서만 물건을 담을 수 있음
- 담는 물품이 재고 초과시 재고의 총량이 담김
- 결제 구현시에는 재고 재확인하는 과정 필요
- 같은 물품을 여러개의 아이디로 다루기에(유통기한 등의 이유) 결제 구현시 각 ID로 적절히 분배할것